### PR TITLE
【修正】ルーティング

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   end
   resources :signup, only: :create
   get 'sell/buydetails', to: 'sell#buydetails'
-  resources :sell, only: [:show] do
+  resources :sell do
     resources :purchase, only: [:show] do
       collection do
         get 'show', to: 'purchase#show'


### PR DESCRIPTION
## What
出品ページ閲覧できないエラー修正

## Why
ルーティングの記述誤りによるエラー修正のため