### PR TITLE
Create card

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,5 +1,5 @@
-document.addEventListener(
-  "DOMContentLoaded", e => {
+document.addEventListener
+  ('turbolinks:load', function(){
     if (document.getElementById("token_submit") != null) { //token_submitというidがnullの場合、下記コードを実行しない
       Payjp.setPublicKey("pk_test_9c4f03af26e6fa05d9f296c7"); //ここに公開鍵を直書き
       let btn = document.getElementById("token_submit"); //IDがtoken_submitの場合に取得されます

--- a/app/assets/stylesheets/buydetails.scss
+++ b/app/assets/stylesheets/buydetails.scss
@@ -88,7 +88,7 @@
     margin-top: 8px;
   }
   &__btn{
-    background: #888;
+    background: #ea352d;
     margin: 16px 0 0;
     padding: 17px;
     width: 100%;

--- a/app/views/purchase/show.html.haml
+++ b/app/views/purchase/show.html.haml
@@ -27,7 +27,7 @@
                 .buydetails-content__pricecell
                   %span.buydetails-content__datapay
                     = @product.jpy
-            .buydetails-content__text 配送先と支払方法の入力を完了してください。
+            .buydetails-content__text
             = form_tag(action: :pay, method: :post) do
               %button.buydetails-content__btn 購入する
       %section.buydetails-content__info

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -23,13 +23,13 @@ crumb :itembuy do |item|
 end
 
 crumb :mypage_card do
-  link '支払い方法'
+  link 'クレジットカード情報入力'
   parent :mypage
 end
 
 crumb :mypage_card_create do
-  link 'クレジットカード情報入力'
-  parent :mypage_card
+  link '支払い方法'
+  parent :mypage
 end
 
 crumb :mypage_profile do


### PR DESCRIPTION
## What
クレジットカード登録をリロードなしで起動するよう修正
購入確認画面のエラーメッセージ削除、購入ボタンを赤色に変更
支払方法のパンくずリストを修正
## Why
本番環境でJSが動かなかったのを直すため
見栄えを整えるため