### PR TITLE
商品購入確認のクレジットカード情報表示

### DIFF
--- a/app/assets/stylesheets/_pickup.scss
+++ b/app/assets/stylesheets/_pickup.scss
@@ -1,9 +1,9 @@
 .pickup-content{
   &__red{
-    border-top: 50px solid red;
+    border-top: 50px solid #ea352d;
     border-right: 50px solid transparent;
     border-bottom: 50px solid transparent;
-    border-left: 50px solid red;
+    border-left: 50px solid #ea352d;
     position: absolute;
     top: 0;
     left: 0;

--- a/app/assets/stylesheets/purchase.scss
+++ b/app/assets/stylesheets/purchase.scss
@@ -8,7 +8,7 @@
 }
 .transact-attention{
   padding: 20px 0;
-  color: red;
+  color: #ea352d;
   background-color: #fff6de;
   font-size: 18px;
   font-weight: 600;

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -12,22 +12,16 @@ class PurchaseController < ApplicationController
   Payjp.api_key = Rails.application.credentials.dig(:payjp, :PAYJP_SECRET_KEY)
 
   def show
-      #ログインチェック
+    card = Card.find_by(user_id: current_user.id)
+    @address_info = Prefecture.find(current_user.prefecture_id).name + current_user.city + current_user.address1 + current_user.address2
+    @full_name = current_user.last_name + current_user.first_name
     if not user_signed_in?
       redirect_to new_user_session_path
-      #登録された情報がない場合にカード登録画面に移動
-    elsif
-      card = Card.find_by(user_id: current_user.id)
     elsif card.blank?
       redirect_to controller: 'card', action: 'new'
     else
-      #Cardテーブルは前回記事で作成、テーブルからpayjpの顧客IDを検索
-      #保管した顧客IDでpayjpから情報取得
       customer = Payjp::Customer.retrieve(card.customer_id)
-      #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
       @default_card_information = customer.cards.retrieve(card.card_id)
-      @address_info = Prefecture.find(current_user.prefecture_id).name + current_user.city + current_user.address1 + current_user.address2
-      @full_name = current_user.last_name + current_user.first_name
     end
   end
 

--- a/app/views/purchase/show.html.haml
+++ b/app/views/purchase/show.html.haml
@@ -50,7 +50,7 @@
             %br /
           - else
             -#以下カード情報を表示
-            = "**** **** **** " + @default_card_information.last4
+            **** **** **** #{@default_card_information.last4}
             - exp_month = @default_card_information.exp_month.to_s
             - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
             = exp_month + " / " + exp_year


### PR DESCRIPTION
## What
クレジットカード情報を持っている人のみ表示
SOLDの色を若干変更
## Why
支払方法の表示を分岐させてどのクレジットカードを使うのかわかるようにするため
メルカリにより近づけるため