### PR TITLE
商品一覧機能の微調整

### DIFF
--- a/app/assets/stylesheets/toppage/toppage_main.scss
+++ b/app/assets/stylesheets/toppage/toppage_main.scss
@@ -1,4 +1,4 @@
-* {
+*, ::before, ::after{
   box-sizing: border-box;
 }
 body {
@@ -83,11 +83,11 @@ body {
     overflow: hidden;
     background-color: #fff;
     border: 0px solid transparent;
-    box-shadow: 0 2px 4px rgba(0,0,0,.18);
+    box-shadow: 0 2px 4px 0 rgba(0,0,0,.18);
     &:hover {
-      border: 1px solid  rgb(0, 149, 238);
+      outline: 1px solid  rgb(0, 149, 238);
     }
-    &__more-link{
+    &__more-link {
       width: 100%;
       height: 100%;
       box-sizing: border-box;

--- a/app/assets/stylesheets/toppage/toppage_main.scss
+++ b/app/assets/stylesheets/toppage/toppage_main.scss
@@ -93,7 +93,6 @@ body {
       box-sizing: border-box;
     }
   }
-     
   &__image {
     width: 188px;
     height: 188px;

--- a/app/controllers/sell_controller.rb
+++ b/app/controllers/sell_controller.rb
@@ -14,10 +14,8 @@ class SellController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @products = Product.all
+    @products = Product.limit(10).order('created_at DESC')
     @category = Category.all
-    # last_product_id = params[:last_id].to_i
-    # @m = where("id > #{last_product_id}") 
   end
 
   def new

--- a/app/views/sell/_main.html.haml
+++ b/app/views/sell/_main.html.haml
@@ -54,7 +54,7 @@
           = link_to 'もっと見る >', '#', class: 'toppage-main__more-link'
       .toppage-main__item
         .toppage-main__contents
-          - @products.order('created_at DESC').limit(10).each do |product|
+          - @products.each do |product|
             .toppage-main__content
               = link_to sell_path(product.id), method: :get do
                 .toppage-main__image
@@ -70,7 +70,7 @@
           = link_to 'もっと見る >', '#', class: 'toppage-main__more-link'
       .toppage-main__item
         .toppage-main__contents
-          - @products.order('created_at DESC').limit(10).each do |product|
+          - @products.each do |product|
             .toppage-main__content
               = link_to sell_path(product.id), method: :get do
                 .toppage-main__image
@@ -86,7 +86,7 @@
           = link_to 'もっと見る >', '#', class: 'toppage-main__more-link'
       .toppage-main__item
         .toppage-main__contents
-          - @products.order('created_at DESC').limit(10).each do |product|
+          - @products.each do |product|
             .toppage-main__content
               = link_to sell_path(product.id), method: :get do
                 .toppage-main__image
@@ -102,7 +102,7 @@
           = link_to 'もっと見る >', '#', class: 'toppage-main__more-link'
       .toppage-main__item
         .toppage-main__contents
-          - @products.order('created_at DESC').limit(10).each do |product|
+          - @products.each do |product|
             .toppage-main__content
               = link_to sell_path(product.id), method: :get do
                 .toppage-main__image


### PR DESCRIPTION
# What
・画像を10枚表示にする定義をビューでなくコントローラーで定義する
・マウスオーバー時にレイアウトが崩れない枠線を設定

# Why
・本番メルカリと同じ仕上がりにするため