### PR TITLE
【修正】トップページのマイページメニュープルダウン

### DIFF
--- a/app/assets/stylesheets/signup/_signup-main.scss
+++ b/app/assets/stylesheets/signup/_signup-main.scss
@@ -221,7 +221,6 @@
   }
   select {
     position: relative;
-    z-index: 2;
     height: 48px;
     padding: 0 16px;
     border-radius: 4px;

--- a/app/assets/stylesheets/toppage/toppage_header.scss
+++ b/app/assets/stylesheets/toppage/toppage_header.scss
@@ -448,6 +448,8 @@ ul.toppage-header-top__footer-search-categories:after{
       float: right;
     }
   }
+
+  // ヘッダーのマイページプルダウン
   &--mypage-nav-list  {
     text-align: left;
     width: 320px;


### PR DESCRIPTION
## What
トップページのマイページプルダウン
「支払い方法」ページを開いた際に有効期限入力フォームが透けないように修正
(有効期限入力フォームのz-index削除)

## Why
支払い方法入力に支障をきたすため

<img width="1067" alt="2019-10-12_トップページのマイページプルダウン" src="https://user-images.githubusercontent.com/54388920/66694526-5fcb2b00-ecef-11e9-98a1-126ec5a53d67.png">