### PR TITLE
【修正】カテゴリー編集アラート誤表示

### DIFF
--- a/app/assets/javascripts/sell.js
+++ b/app/assets/javascripts/sell.js
@@ -138,7 +138,7 @@ $(document).on('turbolinks:load', function(){
   })
 
   // 編集時、カテゴリー追加
-  if(document.URL.match(/edit/)) { 
+  if(document.URL.match(/sell/) && document.URL.match(/edit/)) {
     $(document).ready(function(){
       let sub = $(mainCategory).val();
       let sub_sub = $(subCategory).children('select').val();


### PR DESCRIPTION
## What
「カテゴリー編集に失敗しました」アラート
クレジットカード情報登録時の誤表示、修正

## Why
クレジットカード情報登録に支障をきたすため